### PR TITLE
fix(sri): pin Aioli to immutable versioned biowasm URL (fixes 'Aioli is not defined')

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,21 +76,21 @@
   <script src="resources/js/config.js" defer></script>
   
   <!-- Link to JavaScript Modules -->
-  <script type="module" src="resources/js/inputWrangling.js?v=0.68.0" defer></script>
-  <script type="module" src="resources/js/regionsConfig.js?v=0.68.0" defer></script>
-  <script type="module" src="resources/js/assemblyConfigs.js?v=0.68.0" defer></script>
+  <script type="module" src="resources/js/inputWrangling.js?v=0.68.1" defer></script>
+  <script type="module" src="resources/js/regionsConfig.js?v=0.68.1" defer></script>
+  <script type="module" src="resources/js/assemblyConfigs.js?v=0.68.1" defer></script>
   <!-- bamProcessing.js is lazy-loaded in ExtractionController when needed -->
-  <script type="module" src="resources/js/apiInteractions.js?v=0.68.0" defer></script>
-  <script type="module" src="resources/js/inputValidation.js?v=0.68.0" defer></script>
-  <script type="module" src="resources/js/main.js?v=0.68.0" defer></script>
-  <script type="module" src="resources/js/modal.js?v=0.68.0" defer></script>
-  <script type="module" src="resources/js/mobileNav.js?v=0.68.0" defer></script>
-  <script type="module" src="resources/js/populateRegions.js?v=0.68.0" defer></script>
-  <script type="module" src="resources/js/uiUtils.js?v=0.68.0" defer></script>
-  <script type="module" src="resources/js/usageStats.js?v=0.68.0" defer></script>
+  <script type="module" src="resources/js/apiInteractions.js?v=0.68.1" defer></script>
+  <script type="module" src="resources/js/inputValidation.js?v=0.68.1" defer></script>
+  <script type="module" src="resources/js/main.js?v=0.68.1" defer></script>
+  <script type="module" src="resources/js/modal.js?v=0.68.1" defer></script>
+  <script type="module" src="resources/js/mobileNav.js?v=0.68.1" defer></script>
+  <script type="module" src="resources/js/populateRegions.js?v=0.68.1" defer></script>
+  <script type="module" src="resources/js/uiUtils.js?v=0.68.1" defer></script>
+  <script type="module" src="resources/js/usageStats.js?v=0.68.1" defer></script>
 
   <!-- Version and Current Year Script -->
-  <script type="module" src="resources/js/version.js?v=0.68.0" defer></script>
+  <script type="module" src="resources/js/version.js?v=0.68.1" defer></script>
   
   <!-- Schema.org JSON-LD: WebSite -->
   <script type="application/ld+json">

--- a/index.html
+++ b/index.html
@@ -65,7 +65,10 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/intro.js/4.0.0/intro.min.js" integrity="sha512-+hhhH0eKqYCmXsO28OJE1HHWkgNYwlpceBwmeeDEt5jpCL8jOuqAVunXlZ/WZ4qIluJdwlcv4f5BUIQ/l1w9iw==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
 
   <!-- Include Aioli from BioWasm CDN with Subresource Integrity (SRI) -->
-  <script src="https://biowasm.com/cdn/v3/aioli.js"
+  <!-- Pin to an immutable, version-specific URL. The unversioned /cdn/v3/aioli.js is
+       mutable and gets republished by biowasm, which breaks the SRI hash (and thus
+       leaves `Aioli` undefined). The versioned path serves stable bytes matching the hash. -->
+  <script src="https://biowasm.com/cdn/v3/aioli/3.2.1/aioli.js"
           integrity="sha384-1Ergza974F0w12B/lIP0OD/cMzMizVolHbzSX1Jlmour//ypy41MIN8qYeHl45Jz"
           crossorigin="anonymous" defer></script>
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vntyper-frontend",
-  "version": "0.68.0",
+  "version": "0.68.1",
   "type": "module",
   "description": "VNtyper Online - Frontend testing infrastructure",
   "scripts": {

--- a/resources/js/version.js
+++ b/resources/js/version.js
@@ -3,7 +3,7 @@
 import { logMessage } from './log.js'; // Import the logMessage function
 
 // Frontend Version
-const frontendVersion = '0.68.0'; // Add VNtyper 2 preprint citation and "Read our preprint" call-to-action
+const frontendVersion = '0.68.1'; // Pin Aioli to immutable versioned biowasm CDN URL (fix SRI breakage)
 
 // API Endpoint for Versions
 const versionEndpoint = `${window.CONFIG.API_URL}/version/`;


### PR DESCRIPTION
## Problem (production outage on vntyper.org)

Browser console showed:

```
Failed to find a valid digest in the 'integrity' attribute for resource
'https://biowasm.com/cdn/v3/aioli.js' with computed SHA-384 integrity
'Hd+s2kd2Yde6yoijO+bw5A8cnuc+DyCsbbWJmBuhH8oJq+V2jOurcgbR7NUWVD46'. The resource has been blocked.
Aioli is not defined
```

## Root cause

`index.html` loaded Aioli from the **mutable** URL `https://biowasm.com/cdn/v3/aioli.js` while pinning a Subresource Integrity (SRI) hash. Biowasm **republished** that unversioned file with a newer build:

| URL | Size | SHA-384 |
|-----|------|---------|
| `/cdn/v3/aioli.js` (now) | 17604 | `Hd+s2k…` (new build) |
| `/cdn/v3/aioli/3.2.1/aioli.js` (immutable) | 17364 | `1Ergza…` ← **matches our pin** |

Our pinned hash `sha384-1Ergza…` corresponds exactly to **aioli 3.2.1**. When the mutable file changed, the SHA-384 no longer matched, the browser blocked the script, and `Aioli` never became a global — breaking in-browser BAM region extraction.

## Fix

Point `src` at the **immutable, version-pinned** path `https://biowasm.com/cdn/v3/aioli/3.2.1/aioli.js`, keeping the existing integrity hash (verified to match those exact bytes). This:

- Restores the **exact known-good bytes** the app was built/tested against (zero behavior change — not an upgrade to an untested build).
- Makes future biowasm republishes **unable to break the pin** again.

CSP already allows `https://biowasm.com` in `script-src`, and Aioli's worker/WASM base is baked into the bundle (`/cdn/v3/`, allowed by `connect-src`/`worker-src`), so no CSP changes are needed.

## Verification

`curl` of the pinned URL → `openssl dgst -sha384` → base64 equals the `integrity` attribute (SRI passes).

## Note (separate, pre-existing)

The `(index):46` "inline event handler violates CSP" warning is the intro.js CSS preload `onload="…"` and is unrelated to this outage (tutorial CSS only). Tracked separately.

https://claude.ai/code/session_01BAMVUHqjLRYNhKcrnrd5zL