### PR TITLE
fix(csp): CSP-safe deferred stylesheet loading (remove inline onload handler)

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,8 +42,10 @@
   <!-- Preload LCP image -->
   <link rel="preload" as="image" href="resources/assets/logo/vntyperonline_logo_160px.png">
 
-  <!-- Intro.js CSS (deferred — only needed for tutorial) -->
-  <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/4.0.0/introjs.min.css" as="style" integrity="sha512-631ugrjzlQYCOP9P8BOLEMFspr5ooQwY3rgt8SMUa+QqtVMbY/tniEUOcABHDGjK50VExB4CNc61g5oopGqCEw==" crossorigin="anonymous" referrerpolicy="no-referrer" onload="this.onload=null;this.rel='stylesheet'">
+  <!-- Intro.js CSS (deferred — only needed for tutorial). Promoted to a stylesheet by
+       resources/js/loadDeferredStyles.js (CSP blocks inline onload handlers). -->
+  <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/4.0.0/introjs.min.css" as="style" integrity="sha512-631ugrjzlQYCOP9P8BOLEMFspr5ooQwY3rgt8SMUa+QqtVMbY/tniEUOcABHDGjK50VExB4CNc61g5oopGqCEw==" crossorigin="anonymous" referrerpolicy="no-referrer">
+  <script src="resources/js/loadDeferredStyles.js?v=0.68.2" defer></script>
   <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/4.0.0/introjs.min.css" integrity="sha512-631ugrjzlQYCOP9P8BOLEMFspr5ooQwY3rgt8SMUa+QqtVMbY/tniEUOcABHDGjK50VExB4CNc61g5oopGqCEw==" crossorigin="anonymous" referrerpolicy="no-referrer"></noscript>
 
   <!-- Link to CSS Files -->
@@ -76,21 +78,21 @@
   <script src="resources/js/config.js" defer></script>
   
   <!-- Link to JavaScript Modules -->
-  <script type="module" src="resources/js/inputWrangling.js?v=0.68.1" defer></script>
-  <script type="module" src="resources/js/regionsConfig.js?v=0.68.1" defer></script>
-  <script type="module" src="resources/js/assemblyConfigs.js?v=0.68.1" defer></script>
+  <script type="module" src="resources/js/inputWrangling.js?v=0.68.2" defer></script>
+  <script type="module" src="resources/js/regionsConfig.js?v=0.68.2" defer></script>
+  <script type="module" src="resources/js/assemblyConfigs.js?v=0.68.2" defer></script>
   <!-- bamProcessing.js is lazy-loaded in ExtractionController when needed -->
-  <script type="module" src="resources/js/apiInteractions.js?v=0.68.1" defer></script>
-  <script type="module" src="resources/js/inputValidation.js?v=0.68.1" defer></script>
-  <script type="module" src="resources/js/main.js?v=0.68.1" defer></script>
-  <script type="module" src="resources/js/modal.js?v=0.68.1" defer></script>
-  <script type="module" src="resources/js/mobileNav.js?v=0.68.1" defer></script>
-  <script type="module" src="resources/js/populateRegions.js?v=0.68.1" defer></script>
-  <script type="module" src="resources/js/uiUtils.js?v=0.68.1" defer></script>
-  <script type="module" src="resources/js/usageStats.js?v=0.68.1" defer></script>
+  <script type="module" src="resources/js/apiInteractions.js?v=0.68.2" defer></script>
+  <script type="module" src="resources/js/inputValidation.js?v=0.68.2" defer></script>
+  <script type="module" src="resources/js/main.js?v=0.68.2" defer></script>
+  <script type="module" src="resources/js/modal.js?v=0.68.2" defer></script>
+  <script type="module" src="resources/js/mobileNav.js?v=0.68.2" defer></script>
+  <script type="module" src="resources/js/populateRegions.js?v=0.68.2" defer></script>
+  <script type="module" src="resources/js/uiUtils.js?v=0.68.2" defer></script>
+  <script type="module" src="resources/js/usageStats.js?v=0.68.2" defer></script>
 
   <!-- Version and Current Year Script -->
-  <script type="module" src="resources/js/version.js?v=0.68.1" defer></script>
+  <script type="module" src="resources/js/version.js?v=0.68.2" defer></script>
   
   <!-- Schema.org JSON-LD: WebSite -->
   <script type="application/ld+json">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vntyper-frontend",
-  "version": "0.68.1",
+  "version": "0.68.2",
   "type": "module",
   "description": "VNtyper Online - Frontend testing infrastructure",
   "scripts": {

--- a/resources/js/loadDeferredStyles.js
+++ b/resources/js/loadDeferredStyles.js
@@ -1,0 +1,9 @@
+// frontend/resources/js/loadDeferredStyles.js
+// Promote non-blocking preloaded stylesheets (<link rel="preload" as="style">) to applied
+// stylesheets. This replaces an inline `onload="this.rel='stylesheet'"` handler, which a strict
+// Content-Security-Policy (no 'unsafe-inline' / 'unsafe-hashes') blocks. Setting rel="stylesheet"
+// applies the already-fetched preload without re-downloading and keeps the load non-render-blocking.
+const preloadedStyles = document.querySelectorAll('link[rel="preload"][as="style"]');
+preloadedStyles.forEach(link => {
+  link.rel = 'stylesheet';
+});

--- a/resources/js/version.js
+++ b/resources/js/version.js
@@ -3,7 +3,7 @@
 import { logMessage } from './log.js'; // Import the logMessage function
 
 // Frontend Version
-const frontendVersion = '0.68.1'; // Pin Aioli to immutable versioned biowasm CDN URL (fix SRI breakage)
+const frontendVersion = '0.68.2'; // CSP-safe deferred stylesheet loading (remove inline onload handler)
 
 // API Endpoint for Versions
 const versionEndpoint = `${window.CONFIG.API_URL}/version/`;


### PR DESCRIPTION
## Problem

Console on vntyper.org: `Executing inline event handler violates the following Content Security Policy directive` at `(index):46`.

The intro.js CSS preload used an inline `onload="this.rel='stylesheet'"` handler to load non-render-blocking. The production CSP has no `'unsafe-inline'`/`'unsafe-hashes'`, so inline event handlers are blocked — the swap never ran (tutorial CSS silently not applied), and the console logged a CSP violation on every page load.

## Fix

Move the promotion into a new same-origin script `resources/js/loadDeferredStyles.js` (allowed by `script-src 'self'`) that sets `rel="stylesheet"` on `link[rel="preload"][as="style"]` after parse. CSP-clean, preserves the non-render-blocking preload, no CDN/CSP changes needed. Bumps to 0.68.2.

Unrelated to the Aioli outage fix (0.68.1) — this clears the separate, pre-existing CSP warning.

## Verification
- `npm run lint` + eslint on the new file: clean
- `npm run test:run`: 563 tests pass

https://claude.ai/code/session_01BAMVUHqjLRYNhKcrnrd5zL