### PR TITLE
chore(deps): batch dependency updates and release 0.69.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,13 +25,13 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@v4.37.4
         with:
           languages: javascript-typescript
           # Use security-extended for comprehensive security analysis
           queries: +security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@v4.37.4
         with:
           category: '/language:javascript-typescript'

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -45,7 +45,7 @@ jobs:
           vuln-type: 'os,library'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@v4.37.4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # frontend/Dockerfile
 
-FROM nginx:1.31.2-alpine-slim
+FROM nginx:1.31.3-alpine-slim
 
 # Install gettext, bash, and curl for health checks
 RUN apk add --no-cache gettext bash curl

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
   <!-- Intro.js CSS (deferred — only needed for tutorial). Promoted to a stylesheet by
        resources/js/loadDeferredStyles.js (CSP blocks inline onload handlers). -->
   <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/4.0.0/introjs.min.css" as="style" integrity="sha512-631ugrjzlQYCOP9P8BOLEMFspr5ooQwY3rgt8SMUa+QqtVMbY/tniEUOcABHDGjK50VExB4CNc61g5oopGqCEw==" crossorigin="anonymous" referrerpolicy="no-referrer">
-  <script src="resources/js/loadDeferredStyles.js?v=0.69.0" defer></script>
+  <script src="resources/js/loadDeferredStyles.js?v=0.69.1" defer></script>
   <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/4.0.0/introjs.min.css" integrity="sha512-631ugrjzlQYCOP9P8BOLEMFspr5ooQwY3rgt8SMUa+QqtVMbY/tniEUOcABHDGjK50VExB4CNc61g5oopGqCEw==" crossorigin="anonymous" referrerpolicy="no-referrer"></noscript>
 
   <!-- Link to CSS Files -->
@@ -78,21 +78,21 @@
   <script src="resources/js/config.js" defer></script>
   
   <!-- Link to JavaScript Modules -->
-  <script type="module" src="resources/js/inputWrangling.js?v=0.69.0" defer></script>
-  <script type="module" src="resources/js/regionsConfig.js?v=0.69.0" defer></script>
-  <script type="module" src="resources/js/assemblyConfigs.js?v=0.69.0" defer></script>
+  <script type="module" src="resources/js/inputWrangling.js?v=0.69.1" defer></script>
+  <script type="module" src="resources/js/regionsConfig.js?v=0.69.1" defer></script>
+  <script type="module" src="resources/js/assemblyConfigs.js?v=0.69.1" defer></script>
   <!-- bamProcessing.js is lazy-loaded in ExtractionController when needed -->
-  <script type="module" src="resources/js/apiInteractions.js?v=0.69.0" defer></script>
-  <script type="module" src="resources/js/inputValidation.js?v=0.69.0" defer></script>
-  <script type="module" src="resources/js/main.js?v=0.69.0" defer></script>
-  <script type="module" src="resources/js/modal.js?v=0.69.0" defer></script>
-  <script type="module" src="resources/js/mobileNav.js?v=0.69.0" defer></script>
-  <script type="module" src="resources/js/populateRegions.js?v=0.69.0" defer></script>
-  <script type="module" src="resources/js/uiUtils.js?v=0.69.0" defer></script>
-  <script type="module" src="resources/js/usageStats.js?v=0.69.0" defer></script>
+  <script type="module" src="resources/js/apiInteractions.js?v=0.69.1" defer></script>
+  <script type="module" src="resources/js/inputValidation.js?v=0.69.1" defer></script>
+  <script type="module" src="resources/js/main.js?v=0.69.1" defer></script>
+  <script type="module" src="resources/js/modal.js?v=0.69.1" defer></script>
+  <script type="module" src="resources/js/mobileNav.js?v=0.69.1" defer></script>
+  <script type="module" src="resources/js/populateRegions.js?v=0.69.1" defer></script>
+  <script type="module" src="resources/js/uiUtils.js?v=0.69.1" defer></script>
+  <script type="module" src="resources/js/usageStats.js?v=0.69.1" defer></script>
 
   <!-- Version and Current Year Script -->
-  <script type="module" src="resources/js/version.js?v=0.69.0" defer></script>
+  <script type="module" src="resources/js/version.js?v=0.69.1" defer></script>
   
   <!-- Schema.org JSON-LD: WebSite -->
   <script type="application/ld+json">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vntyper-frontend",
-  "version": "0.69.0",
+  "version": "0.69.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vntyper-frontend",
-      "version": "0.69.0",
+      "version": "0.69.1",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@html-eslint/eslint-plugin": "^0.64.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,19 @@
       "version": "0.69.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@html-eslint/eslint-plugin": "^0.63.0",
-        "@html-eslint/parser": "^0.63.0",
+        "@html-eslint/eslint-plugin": "^0.64.0",
+        "@html-eslint/parser": "^0.64.0",
         "@vitest/browser": "^4.1.9",
         "@vitest/coverage-v8": "^4.1.0",
         "@vitest/ui": "^4.1.0",
-        "eslint": "^10.6.0",
+        "eslint": "^10.8.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
-        "globals": "^17.7.0",
-        "happy-dom": "^20.10.6",
+        "globals": "^17.9.0",
+        "happy-dom": "^20.11.1",
         "jsdom": "^29.1.1",
-        "playwright": "^1.61.1",
-        "prettier": "^3.9.1",
+        "playwright": "^1.62.1",
+        "prettier": "^3.9.6",
         "vitest": "^4.1.0"
       }
     },
@@ -388,9 +388,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -490,13 +490,13 @@
       }
     },
     "node_modules/@html-eslint/core": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/core/-/core-0.63.0.tgz",
-      "integrity": "sha512-fy9Mp8LCcOY4MrJiRoRWULURWYA4KWCKxG5Aa0VNbfR4Zs+CNbSCYjpgOmPr1RIvyHqvbVdeHpHL+iTKLiZnPw==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/core/-/core-0.64.0.tgz",
+      "integrity": "sha512-Iz5x4jRDmcmpdYsYjcw213J/pXZjB8RZ7wIpAmtqGuf7IJX2JwyhfJvTqvuSFYtvHKMMl7Jt0LzmmTklaMuFsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@html-eslint/types": "^0.63.0",
+        "@html-eslint/types": "^0.64.0",
         "html-standard": "^0.0.13"
       },
       "engines": {
@@ -504,18 +504,18 @@
       }
     },
     "node_modules/@html-eslint/eslint-plugin": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/eslint-plugin/-/eslint-plugin-0.63.0.tgz",
-      "integrity": "sha512-C0MLdS1BPeB23G7w4Y+4ojnOXTew8rwNXRK5TlShsNdo4b8GSYe9lt+tCyxPr2B0iz+kqvYEXnKP0HAUsvfUJQ==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/eslint-plugin/-/eslint-plugin-0.64.0.tgz",
+      "integrity": "sha512-Il2z0Pd28/NrHtgALeHiB6uGxRLxxh7WGAOo9k1x18hzN8ibzVXMvswODE3SDrxIzNS2CLJHtqd4VXjU77lL9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint/plugin-kit": "^0.4.1",
-        "@html-eslint/core": "^0.63.0",
-        "@html-eslint/parser": "^0.63.0",
-        "@html-eslint/template-parser": "^0.63.0",
-        "@html-eslint/template-syntax-parser": "^0.63.0",
-        "@html-eslint/types": "^0.63.0",
+        "@html-eslint/core": "^0.64.0",
+        "@html-eslint/parser": "^0.64.0",
+        "@html-eslint/template-parser": "^0.64.0",
+        "@html-eslint/template-syntax-parser": "^0.64.0",
+        "@html-eslint/types": "^0.64.0",
         "@rviscomi/capo.js": "^2.1.0",
         "html-standard": "^0.0.13"
       },
@@ -527,43 +527,43 @@
       }
     },
     "node_modules/@html-eslint/parser": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/parser/-/parser-0.63.0.tgz",
-      "integrity": "sha512-zEPbNVJf0C50l4X1C7FV5ig+c+8veD54HGicMdVc9PgB+cjMGcxgInv8yPbBWSSgSSFZZcFwo/Z4XqcPLPK99Q==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/parser/-/parser-0.64.0.tgz",
+      "integrity": "sha512-DHRfli8lMagO/JwTbg+O5UwDUX2fkNw120BprpPMooVpDIjpi8lv+SK5WzKKW/Dt8j+KRwX3XgTg4ljaYk6tlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@html-eslint/template-syntax-parser": "^0.63.0",
-        "@html-eslint/types": "^0.63.0",
+        "@html-eslint/template-syntax-parser": "^0.64.0",
+        "@html-eslint/types": "^0.64.0",
         "css-tree": "^3.1.0",
         "es-html-parser": "0.3.1"
       }
     },
     "node_modules/@html-eslint/template-parser": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/template-parser/-/template-parser-0.63.0.tgz",
-      "integrity": "sha512-eut/idEvs99oJ4PG1Ipxc/uD/r8PZF6bjJGK02EqFpDRqAnbegEFSR5VKoWMhprbVAyLrtdVeTJKLBdQC8xMpQ==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/template-parser/-/template-parser-0.64.0.tgz",
+      "integrity": "sha512-sFtxhC6prn50D3bkhV38DGl1BH3iyyONNM4VTbXGpE6AMYNsFx/t5W0im4UznZbCXGEeDwolF0d6ehELEBqiDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@html-eslint/types": "^0.63.0",
+        "@html-eslint/types": "^0.64.0",
         "es-html-parser": "0.3.1"
       }
     },
     "node_modules/@html-eslint/template-syntax-parser": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/template-syntax-parser/-/template-syntax-parser-0.63.0.tgz",
-      "integrity": "sha512-MOdc7WmFcMiVbhwPDquXPfR1xTuqhyjy+jh9GEyV4lXYVwX6ATqReLIowZ7z8qNxZ8f9jwQuhktVhHhC6rtiQA==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/template-syntax-parser/-/template-syntax-parser-0.64.0.tgz",
+      "integrity": "sha512-gD5gdJhfz67V91ah+YrwoClKlZIEXfs0xet2UJGo0LHC++AFSCedeMD81EUr9G8TPqHtn0Ke18fdW+wPXRwWvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@html-eslint/types": "^0.63.0"
+        "@html-eslint/types": "^0.64.0"
       }
     },
     "node_modules/@html-eslint/types": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/types/-/types-0.63.0.tgz",
-      "integrity": "sha512-1YclN0Cg2QbUsit0I+SOM2o/66PRcAgw5pkxDjySCOUCbi85DrVZAAbV15ro+YVomYMPqosn3E2IdVCkchgrtQ==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/types/-/types-0.64.0.tgz",
+      "integrity": "sha512-cZrtIXdsnDotdJ8ZPKDyn7d8M6d1TBtBzzCQ+flYSgNY17JtUdBx9Y/QbJlMUdmx0nOWYIniY4PErpygwxt8VA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1512,9 +1512,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
-      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -1524,7 +1524,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -1548,7 +1548,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -1893,9 +1893,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1906,9 +1906,9 @@
       }
     },
     "node_modules/happy-dom": {
-      "version": "20.10.6",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
-      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "version": "20.11.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.1.tgz",
+      "integrity": "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2685,35 +2685,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {
@@ -2781,9 +2781,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.1.tgz",
-      "integrity": "sha512-ppiDo2CSwexck1eyZUwJHg/N3nf1+6IRCv7W/VJ5vaLnVCmB7+3CdRfMwoCHBBX6xTrREDTksZ4OZl5SSf4zXA==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -21,19 +21,19 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@html-eslint/eslint-plugin": "^0.63.0",
-    "@html-eslint/parser": "^0.63.0",
+    "@html-eslint/eslint-plugin": "^0.64.0",
+    "@html-eslint/parser": "^0.64.0",
     "@vitest/browser": "^4.1.9",
     "@vitest/coverage-v8": "^4.1.0",
     "@vitest/ui": "^4.1.0",
-    "eslint": "^10.6.0",
+    "eslint": "^10.8.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
-    "globals": "^17.7.0",
-    "happy-dom": "^20.10.6",
+    "globals": "^17.9.0",
+    "happy-dom": "^20.11.1",
     "jsdom": "^29.1.1",
-    "playwright": "^1.61.1",
-    "prettier": "^3.9.1",
+    "playwright": "^1.62.1",
+    "prettier": "^3.9.6",
     "vitest": "^4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vntyper-frontend",
-  "version": "0.69.0",
+  "version": "0.69.1",
   "type": "module",
   "description": "VNtyper Online - Frontend testing infrastructure",
   "scripts": {

--- a/resources/js/version.js
+++ b/resources/js/version.js
@@ -3,7 +3,7 @@
 import { logMessage } from './log.js'; // Import the logMessage function
 
 // Frontend Version
-const frontendVersion = '0.69.0'; // Correctness: failed jobs, poll errors, storage, blob lifetime, web-root exposure
+const frontendVersion = '0.69.1'; // Dependency maintenance: nginx base image, GitHub Actions, dev dependencies
 
 /**
  * Build the API version endpoint, or null when this page has no API config.


### PR DESCRIPTION
Combines the four open Dependabot PRs into a single tested branch, then bumps the patch version. Each Dependabot commit is cherry-picked with original authorship intact, so closing the source PRs loses no attribution.

Supersedes #110, #111, #112, #113.

## What changed

| Source | Change |
| --- | --- |
| #110 | `nginx` base image `1.31.2-alpine-slim` → `1.31.3-alpine-slim` |
| #111 | `actions/setup-node` v6 → v7 (3 jobs in `ci.yml`) |
| #113 | `github/codeql-action` `@v4` → `@v4.37.4` (init, analyze, upload-sarif) |
| #112 | 7 dev dependencies: `@html-eslint/eslint-plugin` and `@html-eslint/parser` 0.63.0 → 0.64.0, `eslint` 10.6.0 → 10.8.0, `globals` 17.7.0 → 17.9.0, `happy-dom` 20.10.6 → 20.11.1, `playwright` 1.61.1 → 1.62.1, `prettier` 3.9.1 → 3.9.6 |
| — | version 0.69.0 → 0.69.1 in `package.json`, `package-lock.json`, `resources/js/version.js`, and the 13 `?v=` cache busters in `index.html` |

## Verification

Run locally against the merged branch, not against the individual PRs:

- `npm ci` — clean install from the updated lockfile
- `npm run lint` — 0 errors (11 pre-existing warnings, unchanged from main)
- `npm run format:check` — passes under Prettier 3.9.6, no reformatting needed
- `npm run test:run` — **601 passed / 601**, 19 files
- `npm audit --audit-level=critical` — passes (no critical advisories)

The nginx bump is the one change with no test coverage, so the `docker-content.yml` assertions were reproduced locally against a container built from the new base image: all **56 runtime assets returned 200**, all **14 source/tooling paths returned 404** (including the planted `.backup` and `_original/` decoys). `nginx -v` inside the container confirms 1.31.3.

## Notes for the reviewer

- **CodeQL pinning.** #113 changes a floating `@v4` to an exact `@v4.37.4`. That is more reproducible and is what Dependabot will keep current, but it is inconsistent with the rest of the repo, which floats major tags (`actions/checkout@v7`, `actions/setup-node@v7`). Applied as Dependabot proposed — say the word and I will revert those three lines to `@v4`.
- **`npm run lint:check` is red on `main` and stays red here.** It adds `--max-warnings 0`, and 11 warnings (`no-useless-assignment`, `preserve-caught-error`) already exist in `bamProcessing.js` and `unmappedExtraction.js`. Verified against a clean `origin/main` worktree — these predate the ESLint 10.8.0 bump and are not caused by it. CI runs `npm run lint`, not `lint:check`, so the pipeline is unaffected. Worth a separate cleanup PR.
- **`npm audit` reports 3 high / 1 moderate**, all transitive dev-only (`brace-expansion`, `nanoid`, `postcss`, `undici`). None reach the shipped image, which contains no `node_modules`. Not addressed here to keep this PR to the Dependabot changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgrwLpmkmyAR7EjzWL3W4U