### PR TITLE
fix: state the 3-day retention the service will honour

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
           "name": "Is my data secure?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "vntyper.org uses SSL/HTTPS with strong encryption (Mozilla Observatory A+, SSL Labs A+). Only a small fraction of the BAM file is uploaded, preserving privacy. Read data is immediately deleted after computation, and results are kept for 7 days before deletion."
+            "text": "vntyper.org uses SSL/HTTPS with strong encryption (Mozilla Observatory A+, SSL Labs A+). Only a small fraction of the BAM file is uploaded, preserving privacy. Read data is immediately deleted after computation, and results are kept for 3 days before deletion."
           }
         },
         {
@@ -617,7 +617,7 @@
           <h3>Is my data secure?</h3>
           <p>The website https://vntyper.org/ uses SSL/HTTPS protocols with strong encryption and gets a high score for its security implementation (<a href="https://developer.mozilla.org/en-US/observatory/analyze?host=vntyper.org" target="_blank" rel="noopener noreferrer">Mozilla Observatory A+ rating</a>, <a href="https://www.ssllabs.com/ssltest/analyze.html?d=vntyper.org&latest" target="_blank" rel="noopener noreferrer">SSL Labs A+ rating</a>, <a href="https://www.immuniweb.com/ssl/vntyper.org/eqEFlmqX/" target="_blank" rel="noopener noreferrer">ImmuniWeb A+ rating</a>).
             Additionally, only a small fraction of the BAM file is uploaded, preserving privacy and even this read data is immediately deleted after computation.
-            Results are kept for 7 days and then deleted from the server.
+            Results are kept for 3 days and then deleted from the server.
           </p>
         </div>
         <div class="faq-item">


### PR DESCRIPTION
vntyper.org commits to the retention period **publicly, in two places**, and both have to
move together or the site states a period the service does not honour.

| Location | Kind |
| --- | --- |
| `index.html:620` | prose, the "Is my data secure?" FAQ answer |
| `index.html:196` | the same claim inside **JSON-LD `FAQPage` structured data** |

The JSON-LD matters on its own: search engines index it and may surface it as a rich result,
so a stale value there outlives a corrected page for as long as the crawl cache holds. All
three `ld+json` blocks were re-parsed after the edit and remain valid JSON.

**Locale check performed.** This repo has no i18n system; `impressum_de.html` is a German
legal notice carrying no retention claim; and a grep for the retention wording across every
`.html`, `.js`, `.json` and `.md` returns exactly these two lines. Nothing else needs changing.

## Ordering matters, in this direction

This is one of three PRs. VNtyper's
([hassansaei/VNtyper#256](https://github.com/hassansaei/VNtyper/pull/256)) lands first because
it is what the image is built from, and the backend's
([berntpopp/vntyper-online-backend#89](https://github.com/berntpopp/vntyper-online-backend/pull/89))
carries the operator instruction for the untracked server-side `.env.local` that actually
governs the deployed value.

**This page should not lag behind the service.** A site promising 7 days while the service
already keeps 3 sends someone back on day 5 to find their results gone. The reverse — the
page saying 3 while the service still keeps 7 — is merely inaccurate, not harmful. So if the
two cannot land together, this one goes first.

## Why the window is being shortened

Per-job download links are **unauthenticated capability URLs**
([hassansaei/VNtyper#189](https://github.com/hassansaei/VNtyper/issues/189)), so the retention
period is the exposure window for a completed job. 3 days was chosen from what the code
assumes about collection: `vntyper online` polls for at most 4 hours and the completion email
stated no deadline, so the binding case is a person opening that email later —
submit-Friday, download-Monday.

## Raised separately, deliberately not touched here

The FAQ answer carrying this promise is headed **"Is my data secure?"** and answers with SSL
Labs / Mozilla Observatory / ImmuniWeb ratings and minimal upload — transport and
data-minimisation claims — while per-job links are unauthenticated URLs mailed in plaintext.
Transport security and access control are different properties. That is filed as its own
issue rather than reworded here, because what the paragraph *should* say depends on the #189
decision, which has not been made. Changing 7 to 3 is a factual correction that stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YU5VCyuqN9at47bFBfxJP