### PR TITLE
fix: answer the access-control half of "Is my data secure?"

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
           "name": "Is my data secure?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "vntyper.org uses SSL/HTTPS with strong encryption (Mozilla Observatory A+, SSL Labs A+). Only a small fraction of the BAM file is uploaded, preserving privacy. Read data is immediately deleted after computation, and results are kept for 3 days before deletion."
+            "text": "vntyper.org uses SSL/HTTPS with strong encryption (Mozilla Observatory A+, SSL Labs A+). Only a small fraction of the BAM file is uploaded, preserving privacy. Read data is immediately deleted after computation, and results are kept for 3 days before deletion. Note that the results link itself carries no password: anyone who has it can download the results, so it should be treated as confidential."
           }
         },
         {
@@ -618,6 +618,12 @@
           <p>The website https://vntyper.org/ uses SSL/HTTPS protocols with strong encryption and gets a high score for its security implementation (<a href="https://developer.mozilla.org/en-US/observatory/analyze?host=vntyper.org" target="_blank" rel="noopener noreferrer">Mozilla Observatory A+ rating</a>, <a href="https://www.ssllabs.com/ssltest/analyze.html?d=vntyper.org&latest" target="_blank" rel="noopener noreferrer">SSL Labs A+ rating</a>, <a href="https://www.immuniweb.com/ssl/vntyper.org/eqEFlmqX/" target="_blank" rel="noopener noreferrer">ImmuniWeb A+ rating</a>).
             Additionally, only a small fraction of the BAM file is uploaded, preserving privacy and even this read data is immediately deleted after computation.
             Results are kept for 3 days and then deleted from the server.
+          </p>
+          <p>
+            One thing SSL does not cover: your results link is the only thing protecting them.
+            <strong>Anyone who has the link can download your results</strong> &mdash; there is no
+            password on it, and it is sent to you by email in plain text. Treat it like a password:
+            do not forward it or post it anywhere you would not post the data itself.
           </p>
         </div>
         <div class="faq-item">

--- a/index.html
+++ b/index.html
@@ -622,8 +622,8 @@
           <p>
             One thing SSL does not cover: your results link is the only thing protecting them.
             <strong>Anyone who has the link can download your results</strong> &mdash; there is no
-            password on it, and it is sent to you by email in plain text. Treat it like a password:
-            do not forward it or post it anywhere you would not post the data itself.
+            password on it, and it is included directly in the completion email. Treat it like a
+            password: do not forward it or post it anywhere you would not post the data itself.
           </p>
         </div>
         <div class="faq-item">


### PR DESCRIPTION
Closes #123.

The FAQ answer headed **"Is my data secure?"** answered with SSL Labs / Mozilla Observatory /
ImmuniWeb ratings and minimal upload. Those are **transport-security and data-minimisation**
claims. Per-job results come from `/download/{job_id}/`, which takes **no credential** — the
link *is* the capability, and it is included directly in the completion email.

The answer was never false. It answered a narrower question than its heading, and invited the
reader to conclude access control from transport security.

## Why this can land before #189 is decided

The issue said the right wording depends on the open credential-transport decision
([hassansaei/VNtyper#189](https://github.com/hassansaei/VNtyper/issues/189)). It does not, for
the part added here: **a results link is a secret and anyone holding it can retrieve the
results** is true today under every outcome of that decision. If per-job downloads later gain
a credential, this paragraph gets *replaced by better news* — it does not become wrong, and
nothing here pre-empts the choice.

The transport claims are kept. They are true and worth making.

## Both copies move together

- the visible prose in the FAQ answer;
- the **JSON-LD `FAQPage`** answer, which search engines index and may surface as a rich
  result, so a stale copy there outlives a corrected page.

All three `ld+json` blocks re-parsed as valid JSON after the edit.

## Correction: "mailed in plaintext" was wrong

The first revision of this PR — and its commit message, and the body of #123 — said the link
"is mailed in plaintext". That is wrong about the transport, in the direction that alarms:

| Claim | Reality |
| --- | --- |
| plain-text email | the completion mail is built as HTML — [`utils.py:97`](https://github.com/hassansaei/VNtyper/blob/main/docker/app/utils.py#L97) `msg.set_content(content, subtype="html")`, and the link is an `<a href>` in that body ([`tasks.py:405`](https://github.com/hassansaei/VNtyper/blob/main/docker/app/tasks.py#L405)) |
| implied: unencrypted in transit | SMTP delivery upgrades with STARTTLS — [`utils.py:101`](https://github.com/hassansaei/VNtyper/blob/main/docker/app/utils.py#L101) |

"Plain text" was also not what the sentence needed to say. The point is that the link is a
**bearer capability**: it is handed to the reader in the completion email and carries no
credential of its own. The wording is now *"included directly in the completion email"*.

**The access-control claim is unchanged and still correct.** `/download/{job_id}/` carries only
a rate-limit dependency and serves the archive with no authentication —
[`main.py:619`](https://github.com/hassansaei/VNtyper/blob/main/docker/app/main.py#L619),
[`main.py:634`](https://github.com/hassansaei/VNtyper/blob/main/docker/app/main.py#L634).

Commit 06a6a09's message keeps the wrong phrase; the branch is not force-pushed, so the
correction is commit fe55f3c rather than a rewrite. #123 is corrected in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YU5VCyuqN9at47bFBfxJP
